### PR TITLE
Show fetchTarball as well as fetchGit

### DIFF
--- a/src/App/Server.hs
+++ b/src/App/Server.hs
@@ -279,7 +279,19 @@ pageHome request = do
                 H.p $ "Use " <> H.code (toMarkup keyName) <> " in a " <> H.code "nix-shell" <> "."
                 nixCodeBlock $ "nix-shell -p " <> keyName <> " -I nixpkgs=" <> revisionURL hash
 
-                H.p $ "Use " <> H.code (toMarkup name) <> " in a nix script"
+                H.p $ "Use " <> H.code (toMarkup name) <> " in a nix script via tarball"
+                nixCodeBlock $ Text.unlines
+                        [ "let"
+                        , "    pkgs = import (builtins.fetchTarball {"
+                        , "        url = \"" <> revisionURL hash <> "\";"
+                        , "    }) {};"
+                        , ""
+                        , "    myPkg = pkgs." <> keyName <> ";"
+                        , "in"
+                        , "..."
+                        ]
+
+                H.p $ "Use " <> H.code (toMarkup name) <> " in a nix script via Git"
                 nixCodeBlock $ Text.unlines
                         [ "let"
                         , "     pkgs = import (builtins.fetchGit {"


### PR DESCRIPTION
I decided to pass an attribute set instead of a URL to `fetchTarball` so that a user could extend it with other attributes (e.g. `sha256`).

Addresses issue #8.