### PR TITLE
Fix package fetching for nixos-25.11 and nixos-unstable

### DIFF
--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -230,9 +230,17 @@ downloadTo filePath commit =
         --  Enable recursion into attribute sets that nix-env normally
         --  doesn't look into so that we can get a more complete picture
         --  of the available packages for the purposes of the index.
+        -- Inline `recurseIntoAttrs` instead of relying on it being on
+        -- `super`/`super.lib`. Old revisions (nixos-20.03 and earlier)
+        -- only expose it as `super.recurseIntoAttrs` because
+        -- `lib.recurseIntoAttrs` was added later (lands in 20.09).
+        -- Newer revisions (nixos-25.11+) no longer expose it on
+        -- `super` at all. Setting `recurseForDerivations = true` is
+        -- the underlying mechanism and has been stable across every
+        -- revision we index.
         , "  packageOverrides = super: {"
-        , "    haskellPackages = super.recurseIntoAttrs super.haskellPackages;"
-        , "    rPackages = super.recurseIntoAttrs super.rPackages;"
+        , "    haskellPackages = super.haskellPackages // { recurseForDerivations = true; };"
+        , "    rPackages = super.rPackages // { recurseForDerivations = true; };"
         , "  };"
         , "}"
         ]


### PR DESCRIPTION
## Summary

nixpkgs 25.11+ removed `pkgs.recurseIntoAttrs`, so `nix-env -qaP --json` fails for `nixos-25.11`, `nixpkgs-25.11-darwin`, `nixos-unstable`, and `nixpkgs-unstable` — no packages are indexed for those channels.
Inline `recurseForDerivations = true` in `src/Nix.hs` to restore fetching across every indexed channel.

## Cause

Nixpkgs commit [`03bb7d81954d`](https://github.com/NixOS/nixpkgs/commit/03bb7d81954d) "all-packages: do not export lib functions from pkgs" (2025-10-30) moved `recurseIntoAttrs` out of the `pkgs/top-level/all-packages.nix` result attrset, so `super.recurseIntoAttrs` in `packageOverrides` now raises `attribute 'recurseIntoAttrs' missing`.

## Why not switch to `super.lib.recurseIntoAttrs`?

`lib.recurseIntoAttrs` was added in [`8935bfb4ac36`](https://github.com/NixOS/nixpkgs/commit/8935bfb4ac36) (2019-09-11), so it is missing from every release before 20.09.
This project indexes from `nixos-17.03` upward, so neither `super.recurseIntoAttrs` (gone in 25.11+) nor `super.lib.recurseIntoAttrs` (missing pre-20.09) alone covers the full range.

`recurseForDerivations = true` is the underlying mechanism of `recurseIntoAttrs` itself (see `lib/attrsets.nix`) and has been stable across every indexed revision.

## Verification

Reproduced against `nixos-25.11` HEAD (`c7f47036d3df2add644c46d712d14262b7d86c0c`) using the same `nix-env -qaP --json` invocation `src/Nix.hs` runs per commit.

Before (current config with `super.recurseIntoAttrs`):

```
$ nix-env -qaP --json \
    -f https://github.com/NixOS/nixpkgs/archive/c7f47036d3df2add644c46d712d14262b7d86c0c.tar.gz \
    --arg config '{ allowAliases = false; packageOverrides = super: {
      haskellPackages = super.recurseIntoAttrs super.haskellPackages;
      rPackages       = super.recurseIntoAttrs super.rPackages;
    }; }' > /dev/null
error: attribute 'recurseIntoAttrs' missing
# exit 1
```

After (patched config with inlined `recurseForDerivations = true`):

```
$ nix-env -qaP --json \
    -f https://github.com/NixOS/nixpkgs/archive/c7f47036d3df2add644c46d712d14262b7d86c0c.tar.gz \
    --arg config '{ allowAliases = false; packageOverrides = super: {
      haskellPackages = super.haskellPackages // { recurseForDerivations = true; };
      rPackages       = super.rPackages       // { recurseForDerivations = true; };
    }; }' | jq length
127054
# exit 0
```

Cross-check on the oldest indexed release `nixos-17.03` (`2c1838ab99b086dccad930e8dcc504b867149a0c`) — where `super.lib.recurseIntoAttrs` would not exist — with the same patched config:

```
$ nix-env -qaP --json \
    -f https://github.com/NixOS/nixpkgs/archive/2c1838ab99b086dccad930e8dcc504b867149a0c.tar.gz \
    --arg config '{ allowAliases = false; packageOverrides = super: {
      haskellPackages = super.haskellPackages // { recurseForDerivations = true; };
      rPackages       = super.rPackages       // { recurseForDerivations = true; };
    }; }' | jq length
36363
# exit 0
```

related to https://github.com/lazamar/nix-package-versions/issues/58